### PR TITLE
Fix error state when setting existing language after non-existing

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -674,6 +674,9 @@ class GeSHi {
      * @since 1.0.0
      */
     function set_language($language, $force_reset = false) {
+        $this->error = false;
+        $this->strict_mode = GESHI_NEVER;
+
         if ($force_reset) {
             $this->loaded_language = false;
         }
@@ -691,9 +694,6 @@ class GeSHi {
         }
 
         $this->language = $language;
-
-        $this->error = false;
-        $this->strict_mode = GESHI_NEVER;
 
         //Check if we can read the desired file
         if (!is_readable($file_name)) {


### PR DESCRIPTION
See GeSHi::set_language for reference.

``` php
$geshi->set_language('php');
    // $this->loaded_language is "...php.php"
$geshi->set_language('does-not-exist');
    // $this->loaded_language is still "...php.php"
    // $this->error is set to GESHI_ERROR_NO_SUCH_LANG
$geshi->set_language('php');
    // $this->loaded_language is still "...php.php"
    // and $this->error won't be reset to false because the line is below
    // if ($file_name == $this->loaded_language) { return; }
```

Because of the error state, no syntax highlighting for `'php'` will take place until you do a hard reset via `$geshi->set_language('php', true);` or via `$geshi->error = false;` or until you load a different existing language.

GeSHi::parse_code:

``` php
        // Firstly, if there is an error, we won't highlight
        if ($this->error) {
            // ...
            return $result;
        }
```

I don’t suppose this is intentional.

This request contains one quick idea to fix this. It might not be a good one. For instance, I did not check the implications of moving `$this->strict_mode = GESHI_NEVER;`.

In any case, don’t feel obliged to merge. This is meant as a heads up.

Best
