### PR TITLE
Oxygene language: Adding latest keywords & updated the language of the name.

### DIFF
--- a/src/geshi/oxygene.php
+++ b/src/geshi/oxygene.php
@@ -12,6 +12,8 @@
  *
  * CHANGES
  * -------
+ * 2014/01/09 
+ *   -  New keywords & updated languge name
  * 2012/06/28 (1.0.8.11)
  *   -  Added "write" keyword for properties
  * 2010/01/11 (1.0.0)
@@ -38,7 +40,7 @@
  ************************************************************************************/
 
 $language_data = array (
-    'LANG_NAME' => 'Oxygene (Delphi Prism)',
+    'LANG_NAME' => 'Oxygene',
     'COMMENT_SINGLE' => array(1 => '//'),
     'COMMENT_MULTI' => array('(*' => '*)', '{' => '}'),
     //Compiler directives
@@ -58,7 +60,7 @@ $language_data = array (
             'false', 'new', 'ensure', 'require', 'on', 'event', 'delegate', 'method',
             'raise', 'assembly', 'module', 'using','locking', 'old', 'invariants', 'operator',
             'self', 'async', 'finalizer', 'where', 'yield', 'nullable', 'Future',
-            'From',  'Finally', 'dynamic'
+            'From',  'Finally', 'dynamic', 'mapped'
             ),
         2 => array(
             'override', 'virtual', 'External', 'read', 'add', 'remove','final', 'abstract',
@@ -68,7 +70,8 @@ $language_data = array (
             'Implies', 'Select', 'Order', 'By', 'Desc', 'Asc', 'Group', 'Join', 'Take',
             'Skip', 'Concat', 'Union', 'Reverse', 'Distinct', 'Into', 'Equals', 'params',
             'sequence', 'index', 'notify', 'Parallel', 'create', 'array', 'Queryable', 'Aspect',
-            'volatile', 'write'
+            'volatile', 'write', 'autoreleasepool', 'await', 'block', 'deprecated', 'extension',
+            'optional', 'raises', 'selector', 'strong', 'weak', 'tuple', 'unretained'
             ),
         3 => array(
             'chr', 'ord', 'inc', 'dec', 'assert', 'iff', 'assigned','futureAssigned', 'length', 'low', 'high', 'typeOf', 'sizeOf', 'disposeAndNil', 'Coalesce', 'unquote'


### PR DESCRIPTION
All new keywords that were added since this was last changed have been added & the name of the language is just 'Oxygene' now.
