### PR TITLE
TCL comments only preceded by `;`, `{` or a new line.

### DIFF
--- a/src/geshi/tcl.php
+++ b/src/geshi/tcl.php
@@ -50,10 +50,10 @@
 
 $language_data = array (
     'LANG_NAME' => 'TCL',
-    'COMMENT_SINGLE' => array(1 => '#'),
+    'COMMENT_SINGLE' => array(),
     'COMMENT_MULTI' => array(),
     'COMMENT_REGEXP' => array(
-        1 => '/(?<!\\\\)#(?:\\\\\\\\|\\\\\\n|.)*$/m',
+        1 => '/(?:^|(?<=\{|;))\s*#(?:\\\\\\\\|\\\\\\n|.)*$/m',
         //2 => '/{[^}\n]+}/'
         ),
     'CASE_KEYWORDS' => GESHI_CAPS_NO_CHANGE,


### PR DESCRIPTION
Fixes issue #9.
