### PR TITLE
Haskell syntax: omit single quotes from QUOTEMARKS

### DIFF
--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -40,7 +40,7 @@ $language_data = array (
         3 => "/{-(?:(?R)|.)-}/s", //Nested Comments
         ),
     'CASE_KEYWORDS' => 0,
-    'QUOTEMARKS' => array('"',"'"),
+    'QUOTEMARKS' => array('"'),
     'ESCAPE_CHAR' => '\\',
     'KEYWORDS' => array(
         /* main haskell keywords */


### PR DESCRIPTION
Single quotes in Haskell may be used to delimit character literals,
but they can also be used in identifiers. GeSHi's syntax highlighter only
recognizes the former usage. When Haskell source uses "'" as part of an identifier,
GeSHi treats it as the start of a literal string, which screws up syntax
highlighting.

Geshi bug report: http://sourceforge.net/p/geshi/bugs/217/
Geshi proposed patch: http://sourceforge.net/p/geshi/bugs/219/
MediaWiki report: https://bugzilla.wikimedia.org/52509
