### PR TITLE
Do not treat "0" as an empty string

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -595,10 +595,10 @@ class GeSHi {
      * @since 1.0.0
      */
     function GeSHi($source = '', $language = '', $path = '') {
-        if (!empty($source)) {
+        if ($source !== '' ) {
             $this->set_source($source);
         }
-        if (!empty($language)) {
+        if ($language !== '') {
             $this->set_language($language);
         }
         $this->set_language_path($path);


### PR DESCRIPTION
When the source content is "0", the GeSHi class constructor uses the
empty() method and so will consider "0" as an empty string.

This bug has been initially in the Wikimedia bugtracker, for the
SyntaxHighlight (GeSHi) extension.
URL: https://bugzilla.wikimedia.org/show_bug.cgi?id=39643.
A code fix has been submitted to the Wikimedia code review system.
URL: https://gerrit.wikimedia.org/r/#/c/21473/