### PR TITLE
Updated Haskell syntax spec for quote marks.

### DIFF
--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -40,7 +40,7 @@ $language_data = array (
         3 => "/{-(?:(?R)|.)-}/s", //Nested Comments
         ),
     'CASE_KEYWORDS' => 0,
-    'QUOTEMARKS' => array('"',"'"),
+    'QUOTEMARKS' => array('"'),
     'ESCAPE_CHAR' => '\\',
     'KEYWORDS' => array(
         /* main haskell keywords */


### PR DESCRIPTION
In Haskell, only double-quotes are used as quotation marks. Single
quotes are not.