### PR TITLE
Fix nonstandard string highlighting for haskell

### DIFF
--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -152,7 +152,7 @@ $language_data = array (
             0 => 'color: green;'
             ),
         'STRINGS' => array(
-            0 => 'background-color: #3cb371;' /* nice green */
+            0 => 'color: #3cb371;' /* nice green */
             ),
         'NUMBERS' => array(
             0 => 'color: red;' /* pink */


### PR DESCRIPTION
Previously, this highlighter made the *background* of strings green, leaving the text itself black. This means the strings stick out a lot, and the actual content is pretty low contrast. So it draws your eye and then is hard to decipher.

The new way matches [how it is done in OCaml](https://github.com/GeSHi/geshi-1.0/blob/master/src/geshi/ocaml.php#L142) exactly, and is in line with highlighters like the one for Java where [the foreground of strings gets a color](https://github.com/GeSHi/geshi-1.0/blob/master/src/geshi/java.php#L946).