### PR TITLE
Fix Lua syntax highlighting by matching comments non-greedily

### DIFF
--- a/src/geshi/lua.php
+++ b/src/geshi/lua.php
@@ -46,7 +46,7 @@ $language_data = array (
     'LANG_NAME' => 'Lua',
     'COMMENT_SINGLE' => array(1 => "--"),
     'COMMENT_MULTI' => array(),
-    'COMMENT_REGEXP' => array(1 => '/--\[(=*)\[.*\]\1\]/s'),
+    'COMMENT_REGEXP' => array(1 => '/--\[(=*)\[.*?\]\1\]/s'),
     'CASE_KEYWORDS' => GESHI_CAPS_NO_CHANGE,
     'QUOTEMARKS' => array("'", '"'),
     'ESCAPE_CHAR' => '',


### PR DESCRIPTION
This PR matches Lua comments non-greedily. I had a file with a multiline comment somewhere in the file, and another multiline comment at the end of the file, and GeSHi would highlight everything in between as comments.