### PR TITLE
Updated class construct to suppress PHP 7 errors

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -594,7 +594,7 @@ class GeSHi {
      *               {@link GeSHi->set_language_path()}
      * @since 1.0.0
      */
-    function GeSHi($source = '', $language = '', $path = '') {
+    function __construct($source = '', $language = '', $path = '') {
         if (!empty($source)) {
             $this->set_source($source);
         }


### PR DESCRIPTION
GeSHI used a deprecated constructor. It's been phased out in PHP 7 and was complaining about it. I just changed to the regular __construct naming.