### PR TITLE
Fix Lua comment blocks and string blocks.

### DIFF
--- a/src/geshi/lua.php
+++ b/src/geshi/lua.php
@@ -51,8 +51,8 @@ $language_data = array (
         2 => '/--\[(=*)\[.*?\]\1\]/s',
         // Multi line literal strings (should not interpret escape sequences)
         // Here because no STRING_REGEXP
-	3 => '/(?<!--)\[(=*)\[.*?\]\1\]/s',
-    ),
+	3 => '/(?<!--)\[(=*)\[.*?\]\1\]/s'
+    	),
     'CASE_KEYWORDS' => GESHI_CAPS_NO_CHANGE,
     'QUOTEMARKS' => array("'", '"'),
     'ESCAPE_CHAR' => '',
@@ -135,7 +135,7 @@ $language_data = array (
             1 => 'color: #808080; font-style: italic;',
             2 => 'color: #808080; font-style: italic;',
             // Actually a string
-            3 => 'color: #ff0000;',
+            3 => 'color: #ff0000;'
             ),
         'ESCAPE_CHAR' => array(
             0 => 'color: #000099; font-weight: bold;',

--- a/src/geshi/lua.php
+++ b/src/geshi/lua.php
@@ -46,7 +46,13 @@ $language_data = array (
     'LANG_NAME' => 'Lua',
     'COMMENT_SINGLE' => array(1 => "--"),
     'COMMENT_MULTI' => array(),
-    'COMMENT_REGEXP' => array(1 => '/--\[(=*)\[.*\]\1\]/s'),
+    'COMMENT_REGEXP' => array(
+        // Multiline comments
+        2 => '/--\[(=*)\[.*?\]\1\]/s',
+        // Multi line literal strings (should not interpret escape sequences)
+        // Here because no STRING_REGEXP
+	3 => '/(?<!--)\[(=*)\[.*?\]\1\]/s',
+    ),
     'CASE_KEYWORDS' => GESHI_CAPS_NO_CHANGE,
     'QUOTEMARKS' => array("'", '"'),
     'ESCAPE_CHAR' => '',
@@ -127,8 +133,9 @@ $language_data = array (
             ),
         'COMMENTS' => array(
             1 => 'color: #808080; font-style: italic;',
-            //2 => 'color: #ff0000;',
-            'MULTI' => 'color: #808080; font-style: italic;'
+            2 => 'color: #808080; font-style: italic;',
+            // Actually a string
+            3 => 'color: #ff0000;',
             ),
         'ESCAPE_CHAR' => array(
             0 => 'color: #000099; font-weight: bold;',

--- a/src/geshi/lua.php
+++ b/src/geshi/lua.php
@@ -135,7 +135,8 @@ $language_data = array (
             1 => 'color: #808080; font-style: italic;',
             2 => 'color: #808080; font-style: italic;',
             // Actually a string
-            3 => 'color: #ff0000;'
+	    3 => 'color: #ff0000;',
+	    'MULTI' => 'color: #808080; font-style: italic;'
             ),
         'ESCAPE_CHAR' => array(
             0 => 'color: #000099; font-weight: bold;',


### PR DESCRIPTION
Match comments non-greedily instead of greedily
Re-add support for block strings (similar to heredoc)
Wikipedia issue: https://bugzilla.wikimedia.org/show_bug.cgi?id=73281
Wikipedia review: https://gerrit.wikimedia.org/r/173104

This fixues issue #32