### PR TITLE
Introduce strip_language_name and fix null $language error

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -1970,6 +1970,11 @@ class GeSHi {
      * @since 1.0.8
      */
     protected function build_parse_cache() {
+        // check whether language_data is available
+        if (empty($this->language_data)) {
+            return false;
+        }
+
         // cache symbol regexp
         //As this is a costy operation, we avoid doing it for multiple groups ...
         //Instead we perform it for all symbols at once.
@@ -2151,13 +2156,18 @@ class GeSHi {
      *
      * @since 1.0.0
      */
-    public function parse_code () {
+    public function parse_code() {
         // Start the timer
         $start_time = microtime();
 
         // Replace all newlines to a common form.
         $code = str_replace("\r\n", "\n", $this->source);
         $code = str_replace("\r", "\n", $code);
+
+        // check whether language_data is available
+        if (empty($this->language_data)) {
+            $this->error = GESHI_ERROR_NO_SUCH_LANG;
+        }
 
         // Firstly, if there is an error, we won't highlight
         if ($this->error) {

--- a/src/geshi.php
+++ b/src/geshi.php
@@ -628,6 +628,19 @@ class GeSHi {
     }
 
     /**
+     * Clean up the language name to prevent malicious code injection
+     *
+     * @param string $language The name of the language to strip
+     * @since 1.0.9.1
+     */
+    public function strip_language_name($language) {
+        $language = preg_replace('#[^a-zA-Z0-9\-_]#', '', $language);
+        $language = strtolower($language);
+
+        return $language;
+    }
+
+    /**
      * Sets the language for this object
      *
      * @note since 1.0.8 this function won't reset language-settings by default anymore!
@@ -646,9 +659,7 @@ class GeSHi {
         }
 
         //Clean up the language name to prevent malicious code injection
-        $language = preg_replace('#[^a-zA-Z0-9\-_]#', '', $language);
-
-        $language = strtolower($language);
+        $language = $this->strip_language_name($language);
 
         //Retreive the full filename
         $file_name = $this->language_path . $language . '.php';


### PR DESCRIPTION
- Introduce a `strip_language_name` public function; it will benefit apps as a standard sanitation interface for the language, because some apps (like DokuWiki) need to handle the language name for other use;
- Prevent errors when `$language == ""` (or no language data is loaded) by adding checks in `build_parse_cache` and `parse_code`.