### PR TITLE
Haskell doc fix

### DIFF
--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -116,7 +116,7 @@ $language_data = array (
             'Floating', 'RealFrac', 'RealFloat',
 	    'Semigroup', 'Monoid',
             'Monad', 'Applicative', 'Functor',
-	    'Foldable', 'Traversable', 
+	    'Foldable', 'Traversable',
             'Show', 'Read'
             )
         ),

--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -114,9 +114,9 @@ $language_data = array (
             'Ord', 'Eq', 'Enum', 'Bounded',
             'Num', 'Real', 'Integral', 'Fractional',
             'Floating', 'RealFrac', 'RealFloat',
-	    'Semigroup', 'Monoid',
+            'Semigroup', 'Monoid',
             'Monad', 'Applicative', 'Functor',
-	    'Foldable', 'Traversable',
+            'Foldable', 'Traversable',
             'Show', 'Read'
             )
         ),

--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -105,7 +105,7 @@ $language_data = array (
         4 => array (
             'Bool', 'Maybe', 'Either', 'Ordering',
             'Char', 'String',
-            'Int', 'Integer', 'Float', 'Double', 'Rational',
+            'Int', 'Integer', 'Float', 'Double', 'Rational', 'Word',
             'ShowS', 'ReadS',
             'IO', 'IOError', 'IOException'
             ),
@@ -114,7 +114,9 @@ $language_data = array (
             'Ord', 'Eq', 'Enum', 'Bounded',
             'Num', 'Real', 'Integral', 'Fractional',
             'Floating', 'RealFrac', 'RealFloat',
-            'Monad', 'Functor',
+	    'Semigroup', 'Monoid',
+            'Monad', 'Applicative', 'Functor',
+	    'Foldable', 'Traversable', 
             'Show', 'Read'
             )
         ),

--- a/src/geshi/haskell.php
+++ b/src/geshi/haskell.php
@@ -172,13 +172,13 @@ $language_data = array (
         /* some of keywords are Prelude functions */
         1 => '',
         /* link to the wanted library */
-        2 => 'http://haskell.org/ghc/docs/latest/html/libraries/base/{FNAME}.html',
+        2 => 'http://hackage.haskell.org/package/base/docs/{FNAME}.html',
         /* link to Prelude functions */
-        3 => 'http://haskell.org/ghc/docs/latest/html/libraries/base/Prelude.html#v:{FNAME}',
+        3 => 'http://hackage.haskell.org/package/base/docs/Prelude.html#v:{FNAME}',
         /* link to Prelude types */
-        4 => 'http://haskell.org/ghc/docs/latest/html/libraries/base/Prelude.html#t:{FNAME}',
+        4 => 'http://hackage.haskell.org/package/base/docs/Prelude.html#t:{FNAME}',
         /* link to Prelude exceptions */
-        5 => 'http://haskell.org/ghc/docs/latest/html/libraries/base/Prelude.html#t:{FNAME}'
+        5 => 'http://hackage.haskell.org/package/base/docs/Prelude.html#t:{FNAME}'
         ),
     'OOLANG' => false,
     'OBJECT_SPLITTERS' => array(


### PR DESCRIPTION
Haskell online documentation lives at new URLs (hackage).
Also newer Haskell Prelude classes and types were not recognized by GeSHi