### PR TITLE
Additions to bash language file

### DIFF
--- a/src/geshi/bash.php
+++ b/src/geshi/bash.php
@@ -88,10 +88,12 @@ $language_data = array (
         5 => "/`[^`]*`/"
         ),
     'KEYWORDS' => array(
+        // Control flow keywords and super-important builtins
         1 => array(
             'case', 'do', 'done', 'elif', 'else', 'esac', 'fi', 'for', 'function',
-            'if', 'in', 'select', 'set', 'then', 'until', 'while', 'time'
+            'if', 'in', 'select', 'set', 'then', 'time', 'until', 'while'
             ),
+        // Common Unix commands
         2 => array(
             'aclocal', 'aconnect', 'apachectl', 'apache2ctl', 'aplay', 'apm',
             'apmsleep', 'apropos', 'apt-cache', 'apt-cdrom', 'apt-config',
@@ -365,15 +367,16 @@ $language_data = array (
             'zgrep', 'zip', 'zipgrep', 'zipinfo', 'zless', 'zmore', 'znew',
             'zsh', 'zsoelim'
             ),
+        // Builtin commands
         3 => array(
-            'alias', 'bg', 'bind', 'break', 'builtin', 'cd', 'command',
-            'compgen', 'complete', 'continue', 'declare', 'dirs', 'disown',
+            'alias', 'bg', 'bind', 'break', 'builtin', 'caller', 'cd', 'command',
+            'compgen', 'complete', 'compopt', 'continue', 'coproc', 'declare', 'dirs', 'disown',
             'echo', 'enable', 'eval', 'exec', 'exit', 'export', 'fc',
-            'fg', 'getopts', 'hash', 'help', 'history', 'jobs', 'let',
-            'local', 'logout', 'popd', 'printf', 'pushd', 'pwd', 'readonly',
-            'return', 'shift', 'shopt', 'source', 'suspend', 'test', 'times',
-            'trap', 'type', 'typeset', 'ulimit', 'umask', 'unalias', 'unset',
-            'wait'
+            'fg', 'getopts', 'hash', 'help', 'history', 'jobs', 'kill', 'let',
+            'local', 'logout', 'mapfile', 'popd', 'printf', 'pushd', 'pwd', 'read',
+            'readarray', 'readonly', 'return', 'shift', 'shopt', 'source',
+            'suspend', 'test', 'times', 'trap', 'type', 'typeset', 'ulimit',
+            'umask', 'unalias', 'unset', 'wait'
             )
         ),
     'SYMBOLS' => array(


### PR DESCRIPTION
A couple tweaks to the bash language file:

Add some missing builtins: caller, compopt, coproc, kill, mapfile, read, readarray.
Reorder keywords to be alphabetical, as requested by the help.
Add comments indicating which each of the keywords sections represent.
