### PR TITLE
Documentation typo and formatting fixes

### DIFF
--- a/docs/geshi-doc.html
+++ b/docs/geshi-doc.html
@@ -2,7 +2,7 @@
  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
     <head>
-        <title>GeSHi Documentation 1.0.9.0</title>
+      <title>GeSHi Documentation 1.0.9.0</title>
 
     	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     	<meta name="keywords" content="GeSHi, syntax, highlighter, colorizer, beautifier, code, generic, php, sql, css, html, syntax, highlighting, documentation" />
@@ -201,7 +201,7 @@
  * GeSHi Dynamically Generated Stylesheet
  * --------------------------------------
  * Dynamically generated stylesheet for bash
- * CSS class: , CSS id: 
+ * CSS class: , CSS id:
  * GeSHi (C) 2004 - 2007 Nigel McNie, 2007 - 2008 Benny Baumann
  * (http://qbnz.com/highlighter/ and http://geshi.org/)
  * --------------------------------------
@@ -243,7 +243,7 @@
  * GeSHi Dynamically Generated Stylesheet
  * --------------------------------------
  * Dynamically generated stylesheet for php
- * CSS class: , CSS id: 
+ * CSS class: , CSS id:
  * GeSHi (C) 2004 - 2007 Nigel McNie, 2007 - 2008 Benny Baumann
  * (http://qbnz.com/highlighter/ and http://geshi.org/)
  * --------------------------------------
@@ -290,7 +290,7 @@
  * GeSHi Dynamically Generated Stylesheet
  * --------------------------------------
  * Dynamically generated stylesheet for html4strict
- * CSS class: , CSS id: 
+ * CSS class: , CSS id:
  * GeSHi (C) 2004 - 2007 Nigel McNie, 2007 - 2008 Benny Baumann
  * (http://qbnz.com/highlighter/ and http://geshi.org/)
  * --------------------------------------
@@ -320,7 +320,7 @@
  * GeSHi Dynamically Generated Stylesheet
  * --------------------------------------
  * Dynamically generated stylesheet for css
- * CSS class: , CSS id: 
+ * CSS class: , CSS id:
  * GeSHi (C) 2004 - 2007 Nigel McNie, 2007 - 2008 Benny Baumann
  * (http://qbnz.com/highlighter/ and http://geshi.org/)
  * --------------------------------------
@@ -353,7 +353,7 @@
  * GeSHi Dynamically Generated Stylesheet
  * --------------------------------------
  * Dynamically generated stylesheet for java
- * CSS class: , CSS id: 
+ * CSS class: , CSS id:
  * GeSHi (C) 2004 - 2007 Nigel McNie, 2007 - 2008 Benny Baumann
  * (http://qbnz.com/highlighter/ and http://geshi.org/)
  * --------------------------------------
@@ -537,7 +537,7 @@ make use of <abbr title="Cascading Style Sheets">CSS</abbr> to save on the amoun
 
 <dl>
 <dt>Programmed in <abbr title="PHP: HTML Preprocessor">PHP</abbr>:</dt>
-<dd><abbr title="Generic Syntax Highlighter">GeSHi</abbr> is coded entirely in <abbr title="PHP: HTML Preprocessor">PHP</abbr>. This means that where ever you have <abbr title="PHP: HTML Preprocessor">PHP</abbr>, you
+<dd><abbr title="Generic Syntax Highlighter">GeSHi</abbr> is coded entirely in <abbr title="PHP: HTML Preprocessor">PHP</abbr>. This means that wherever you have <abbr title="PHP: HTML Preprocessor">PHP</abbr>, you
 can have <abbr title="Generic Syntax Highlighter">GeSHi</abbr>! Almost any free webhost supports <abbr title="PHP: HTML Preprocessor">PHP</abbr>, and <abbr title="Generic Syntax Highlighter">GeSHi</abbr> works fine with <abbr title="PHP: HTML Preprocessor">PHP</abbr> > 4.3.0<sup id="fnref:php-version-note"><a href="#fn:php-version-note" rel="footnote">2</a></sup>.</dd>
 
 <dt>Support for many languages:</dt>
@@ -546,7 +546,7 @@ can have <abbr title="Generic Syntax Highlighter">GeSHi</abbr>! Almost any free 
 
 <dt>XHTML compliant output:</dt>
 <dd><abbr title="Generic Syntax Highlighter">GeSHi</abbr> produces XHTML compliant output, using stylesheets, so you need not worry about
-<abbr title="Generic Syntax Highlighter">GeSHi</abbr> ruining your claims to perfection in the standards department ;)</dd>
+<abbr title="Generic Syntax Highlighter">GeSHi</abbr> ruining your claims to perfection in the standards department. ;)</dd>
 
 <dt>Highly customisable:</dt>
 <dd><abbr title="Generic Syntax Highlighter">GeSHi</abbr> allows you to change the style of the output on the fly, use <abbr title="Cascading Style Sheets">CSS</abbr> classes or not, use an external
@@ -576,7 +576,7 @@ for phpBB<sup id="fnref:phpbb-note"><a href="#fn:phpbb-note" rel="footnote">3</a
 <li><a href="http://www.php-fusion.co.uk/"><abbr title="PHP: HTML Preprocessor">PHP</abbr>-Fusion</a> - A constantly evolving CMS</li>
 <li><a href="http://cypreess.dione.cc/sqlm">SQL Manager</a> - A Postgres DBAL</li>
 <li><a href="http://www.mamboserver.com/">Mambo</a> - A popular open source CMS</li>
-<li><a href="http://www.mediawiki.org/">MediaWiki</a> - A leader in Wikis[^plugin-only]</li>
+<li><a href="http://www.mediawiki.org/">MediaWiki</a> - A leader in Wikis<sup id="fnref:plugin-only"><a href="#fn:plugin-only" rel="footnote">4</a></sup></li>
 <li><a href="http://www.tikiwiki.org/">TikiWiki</a> - A megapowerful Wiki/CMS</li>
 <li><a href="http://www.tikipro.org/">TikiPro</a> - Another powerful Wiki based on TikiWiki</li>
 <li><a href="http://www.wikkawiki.org/">WikkaWiki</a> - A flexible and lightweight Wiki engine</li>
@@ -584,18 +584,18 @@ for phpBB<sup id="fnref:phpbb-note"><a href="#fn:phpbb-note" rel="footnote">3</a
 </ul>
 
 <p><abbr title="Generic Syntax Highlighter">GeSHi</abbr> is the original work of <a href="mailto:nigel@geshi.org">Nigel McNie</a>. The project was later handed over to <a href="mailto:BenBE@geshi.org">Benny Baumann</a>.
-Others have helped with aspects of <abbr title="Generic Syntax Highlighter">GeSHi</abbr> also, they&#8217;re mentioned in the <a href="THANKS"><code>THANKS</code></a> file.</p>
+Others have helped with aspects of <abbr title="Generic Syntax Highlighter">GeSHi</abbr> also; they&#8217;re mentioned in the <a href="THANKS"><code>THANKS</code></a> file.</p>
 
 <h3 id="credits">1.3 Credits</h3><div class="nav"><a href="#about-geshi">Previous</a> | <a href="#introduction">Top</a> | <a href="#feedback">Next</a></div>
 
 <p>Many people have helped out with <abbr title="Generic Syntax Highlighter">GeSHi</abbr>, whether by creating language files, submitting bug
 reports, suggesting new ideas or simply pointing out a new idea or something I&#8217;d missed. All
-of these people have helped to build a better <abbr title="Generic Syntax Highlighter">GeSHi</abbr>, you can see them in the <a href="THANKS"><code>THANKS</code></a>
+of these people have helped to build a better <abbr title="Generic Syntax Highlighter">GeSHi</abbr>; you can see them in the <a href="THANKS"><code>THANKS</code></a>
 file.</p>
 
 <p>Do you want your name on this list? Why not make a language file, or submit a valid bug? Or perhaps help me with an
 added feature I can&#8217;t get my head around, or suggest a new feature, or even port
-<abbr title="Generic Syntax Highlighter">GeSHi</abbr> to anothe language? There&#8217;s lots you can do to help out, and I need it all :)</p>
+<abbr title="Generic Syntax Highlighter">GeSHi</abbr> to anothe language? There&#8217;s lots you can do to help out, and I need it all. :)</p>
 
 <h3 id="feedback">1.4 Feedback</h3><div class="nav"><a href="#credits">Previous</a> | <a href="#introduction">Top</a> | <a href="#the-basics">Next</a></div>
 
@@ -605,11 +605,12 @@ the best it can be, and I need your help! You can contact me in the following wa
 
 <ul>
 <li><strong>E-mail:</strong>  <a href="mailto:nigel@geshi.org">Nigel McNie</a>, <a href="mailto:BenBE@geshi.org">Benny Baumann</a> or better yet: use the <a href="http://lists.sourceforge.net/mailman/listinfo/geshi-users">geshi-users</a> mailinglist</li>
+<li><strong>Issue tracker:</strong> <a href="https://github.com/GeSHi/geshi-1.0/issues">geshi-1.0</a> repo on GitHub
 <li><strong>Forums:</strong>  <a href="http://sourceforge.net/forum?group_id=114997">Sourceforge.net Forums</a></li>
 <li><strong>IRC:</strong> <a href="irc://irc.freenode.net/geshi">#geshi</a> on <a href="http://freenode.net">Freenode</a></li>
 </ul>
 
-<p>Remember, any help I am grateful for :)</p>
+<p>Remember, any help I am grateful for. :)</p>
 
 <h2 id="the-basics">2 The Basics</h2><div class="nav"><a href="#feedback">Previous</a> | <a href="#getting-geshi">Next</a></div>
 
@@ -662,7 +663,7 @@ guaranteed to be tested and stable at all times. With this version you&#8217;ll 
 will be loads of them here! So this is absolutely <strong>not recommended</strong> for productive use!</li>
 </ul>
 
-<p>If you have choosen the right SVN directory for you do a quick
+<p>If you have chosen the right SVN directory for you, do a quick
 <code class="highlighted bash"><span class="kw2">svn co</span> <span class="re1">$SVNPATH</span> geshi</code> where <code class="highlighted bash"><span class="co4">$</span>SVNPATH</code> is one of the above paths and your desired version of <abbr title="Generic Syntax Highlighter">GeSHi</abbr> will be
 downloaded into an subdirectory called &#8220;geshi&#8221;. If you got a version of <abbr title="Generic Syntax Highlighter">GeSHi</abbr>
 you can go on installing as shown below.</p>
@@ -670,7 +671,7 @@ you can go on installing as shown below.</p>
 <h4 id="extracting-geshi">2.1.3 Extracting <abbr title="Generic Syntax Highlighter">GeSHi</abbr></h4><div class="nav"><a href="#downloading-geshi">Previous</a> | <a href="#getting-geshi">Top</a> | <a href="#installing-geshi">Next</a></div>
 
 <p>Packages come in <code>.zip</code>, <code>.tar.gz</code> and <code>.tar.bz2</code> format, so there&#8217;s no complaining about whether it&#8217;s available for
-you. *nix users probably want <code>.tar.gz</code> or <code>.tar.bz2</code> and windows users probably want <code>.zip</code>.
+you. *nix users probably want <code>.tar.gz</code> or <code>.tar.bz2</code> and Windows users probably want <code>.zip</code>.
 And those lucky to download it directly from SVN don&#8217;t even need to bother extracting <abbr title="Generic Syntax Highlighter">GeSHi</abbr>.</p>
 
 <p>To extract <abbr title="Generic Syntax Highlighter">GeSHi</abbr> in Linux (<code>.tar.gz</code>):</p>
@@ -802,7 +803,7 @@ path to the language files as well as the source. Here are some examples:</p>
 <span class="xtra li2"><span class="de2"><span class="kw1">else</span></span></span><span class="br0">&#123;</span>
 <span class="xtra li2"><span class="de2">&nbsp; &nbsp; <span class="co1">// All OK :)</span></span></span><span class="br0">&#125;</span></pre></td></tr></tbody></table>
 
-<p>However, these are really simple examples and doesn&#8217;t even begin to cover all the advanced features of <abbr title="Generic Syntax Highlighter">GeSHi</abbr>.
+<p>However, these are really simple examples and don&#8217;t even begin to cover all the advanced features of <abbr title="Generic Syntax Highlighter">GeSHi</abbr>.
 If you want to learn more, continue on to section 3: Advanced Features.</p>
 
 <h2 id="advanced-features">3 Advanced Features</h2><div class="nav"><a href="#basic-usage">Previous</a> | <a href="#the-code-container">Next</a></div>
@@ -849,9 +850,9 @@ defines the container type. Available are:</p>
 <dl>
 <dt><code class="highlighted php"><span class="re0">$geshi</span><span class="sy0">-&gt;</span><span class="me1">set_header_type</span><span class="br0">&#40;</span>GESHI_HEADER_DIV<span class="br0">&#41;</span><span class="sy0">;</span></code></dt>
 <dd>
-<p>Puts a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">div</span>&gt;</span></code> around both, code and linenumbers. Whitespace is converted to <code class="highlighted html4strict"><span class="sc1">&amp;nbsp;</span></code>
+<p>Puts a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">div</span>&gt;</span></code> around both code and linenumbers. Whitespace is converted to <code class="highlighted html4strict"><span class="sc1">&amp;nbsp;</span></code>
 sequences (i.e. one whitespace and the html entity of a non-breaking whitespace) to keep your indendation level
-in tact. Tabs are converted as well and you can manually <a href="#setting-tab-width">define the tab-width</a>. Lines are automatically wrapped.
+intact. Tabs are converted as well and you can manually <a href="#setting-tab-width">define the tab-width</a>. Lines are automatically wrapped.
 Linenumbers are created using an ordered list.</p>
 </dd>
 
@@ -913,7 +914,7 @@ in what is used as the Code Container (although it <em>should</em> simply use a 
 <p>The default styles for the <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">pre</span>&gt;</span></code> and <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">div</span>&gt;</span></code> <em>will be different</em>, especially if you use
   line numbers!</p>
 
-<p>I have found that a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">pre</span>&gt;</span></code> results in code that is smaller than for that of a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">div</span>&gt;</span></code>, you
+<p>I have found that a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">pre</span>&gt;</span></code> results in code that is smaller than for that of a <code class="highlighted html4strict"><span class="sc2">&lt;<span class="kw2">div</span>&gt;</span></code>; you
   should rectify this difference by using <strong><code class="highlighted php">set_overall_style<span class="br0">&#40;</span><span class="br0">&#41;</span></code></strong> if you need to. But be aware of this
   difference for if you are changing the header type!</p>
 
@@ -979,7 +980,7 @@ numbers too! Not such a good thing, but thankfully this issue is now solved. Wha
 whole way that styles are inherited/used has changed for those of you who were familiar with 1.0.1, and there is
 quite a bit more <abbr title="Hypertext Markup Language">HTML</abbr> involved. So think carefully about these things before you enable line numbers.</p>
 
-<p>Now, onto how to style line numbers:</p>
+<p>Now, on to how to style line numbers:</p>
 
 <p>Styles are set for line numbers using the <code class="highlighted php">set_line_style<span class="br0">&#40;</span><span class="br0">&#41;</span></code> method:</p>
 
@@ -1004,7 +1005,7 @@ quite a bit more <abbr title="Hypertext Markup Language">HTML</abbr> involved. S
 <div class="note-header">Note:</div>
 
 <p>Due to a bug with Firefox the issue that should have been fixed with 1.0.2 has reappeared in another form as Firefox
-  includes extra text\markup into plaintext versions of webpage copies. This can sometimes be useful (actually it&#8217;s
+  includes extra text/markup into plaintext versions of webpage copies. This can sometimes be useful (actually it&#8217;s
   used to get the plaintext version of this documentation), but more often is quite annoying. Best practice so far is
   to either not use line numbers, or offer the visitor of your page a plaintext version of your source. To learn more
   have a look at the <a href="http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1651996&amp;group_id=114997&amp;atid=670231">SF.net BugTracker Issue #1651996</a>. This will hopefully be fixed in <abbr title="Generic Syntax Highlighter">GeSHi</abbr> version 1.2
@@ -1065,8 +1066,8 @@ those who will view the code. You set the line numbers by calling the <code clas
 
 <h3 id="using-css-classes">3.3 Using <abbr title="Cascading Style Sheets">CSS</abbr> Classes</h3><div class="nav"><a href="#starting-line-numbers">Previous</a> | <a href="#advanced-features">Top</a> | <a href="#enabling-css-classes">Next</a></div>
 
-<p>Using <abbr title="Cascading Style Sheets">CSS</abbr> to highlight your code instead of in-lining the styles is a definate bonus. Not only is it more compliant
-(the w3c is deprecating the style attribute in XHTML 2.0) but it results in far less outputted code - up to a whopping
+<p>Using <abbr title="Cascading Style Sheets">CSS</abbr> to highlight your code instead of in-lining the styles is a definete bonus. Not only is it more compliant
+(the W3C is deprecating the style attribute in XHTML 2.0) but it results in far less outputted code - up to a whopping
 90% saving - which makes a &#42;huge&#42; difference to those unlucky of us on modems!</p>
 
 <h4 id="enabling-css-classes">3.3.1 Enabling <abbr title="Cascading Style Sheets">CSS</abbr> Classes</h4><div class="nav"><a href="#using-css-classes">Previous</a> | <a href="#using-css-classes">Top</a> | <a href="#setting-css-class-id">Next</a></div>
@@ -1083,7 +1084,7 @@ the use of classes on, you call the <code class="highlighted php">enable_classes
 
 <p>If classes are enabled when <code class="highlighted php">parse_code<span class="br0">&#40;</span><span class="br0">&#41;</span></code> is called, then the resultant source will use <abbr title="Cascading Style Sheets">CSS</abbr> classes in the
 output, otherwise it will in-line the styles. The advantages of using classes are great - the reduction in source will
-be very noticeable, and what&#8217;s more you can use one stylesheet for several different highlights on the same page. In
+be very noticeable, and what&#8217;s more you, can use one stylesheet for several different highlights on the same page. In
 fact, you can even use an external stylesheet and link to that, saving even more time and source (because stylesheets
 are cached by browsers).</p>
 
@@ -1157,12 +1158,12 @@ get a stylesheet for your code, with one easy method call:</p>
 
 <p>The <code class="highlighted php">get_stylesheet<span class="br0">&#40;</span><span class="br0">&#41;</span></code> method gets the stylesheet for your code in one easy call. All you need to do
 is output it in the correct place. As you can also see, you don&#8217;t even have to enable class usage to get the
-stylesheet nessecary either - however not enabling classes but using the stylesheet may result in problems later.</p>
+stylesheet necessary either - however not enabling classes but using the stylesheet may result in problems later.</p>
 
 <p>By default, <code class="highlighted php">get_stylesheet<span class="br0">&#40;</span><span class="br0">&#41;</span></code> tries to echo the least amount of code possible. Although currently it doesn&#8217;t
-check to see if a certain lexic is even in the source, you can expect this feature in the future. At least for the
+check to see if a certain lexic is even in the source; you can expect this feature in the future. At least for the
 present however, if you explicitly disable the highlighting of a certain lexic, or disable line numbers, the related
-<abbr title="Cascading Style Sheets">CSS</abbr> will not be outputted. This may be a bad thing for you perhaps you&#8217;re going to use the stylesheet for many blocks
+<abbr title="Cascading Style Sheets">CSS</abbr> will not be outputted. This may be a bad thing for you; perhaps you&#8217;re going to use the stylesheet for many blocks
 of code, some with line numbers, others with some lexic enabled where this source has it disabled. Or perhaps you&#8217;re
 building an external stylesheet and want all lexics included. So to get around this problem, you do this:</p>
 
@@ -1212,7 +1213,7 @@ highlighted differently. Here&#8217;s how you can do that:</p>
 <span class="xtra li2"><span class="de2"><span class="kw1">echo</span> <span class="st_h">'&lt;html&gt;</span></span></span><span class="st_h">&lt;head&gt;&lt;title&gt;Code&lt;/title&gt;</span>
 <span class="xtra li2"><span class="de2">&nbsp;</span></span><span class="st_h">&lt;style type=&quot;text/css&quot;&gt;</span>
 <span class="xtra li2"><span class="de2"><span class="st_h">&lt;!--</span></span></span><span class="st_h">'</span><span class="sy0">;</span>
-<span class="xtra li2"><span class="de2">&nbsp;</span></span><span class="co1">// Get the nessecary stylesheets</span>
+<span class="xtra li2"><span class="de2">&nbsp;</span></span><span class="co1">// Get the necessary stylesheets</span>
 <span class="xtra li2"><span class="de2"><span class="kw1">echo</span> <span class="re0">$geshi1</span><span class="sy0">-&gt;</span><span class="me1">get_stylesheet</span><span class="br0">&#40;</span><span class="br0">&#41;</span><span class="sy0">;</span></span></span>&nbsp;
 <span class="xtra li2"><span class="de2"><span class="kw1">echo</span> <span class="re0">$geshi3</span><span class="sy0">-&gt;</span><span class="me1">get_stylesheet</span><span class="br0">&#40;</span><span class="br0">&#41;</span><span class="sy0">;</span></span></span>&nbsp;
 <span class="xtra li2"><span class="de2"><span class="kw1">echo</span> <span class="st_h">'--&gt;</span></span></span><span class="st_h">&lt;/style&gt;&lt;/head&gt;</span>
@@ -1337,7 +1338,7 @@ a particular set, you&#8217;ll have to know what the set is called first. Sets a
 contains keywords like <code>if</code>, <code>while</code>, <code>do</code>, <code>for</code>, <code>switch</code> etc, set 2 contains <code>null</code>, <code>false</code>, <code>true</code> etc, set 3
 contains function inbuilt into the language (<code>echo</code>, <code>htmlspecialchars</code> etc. in <abbr title="PHP: HTML Preprocessor">PHP</abbr>) and set 4 contains data types and
 similar variable modifiers: <code>int</code>, <code>double</code>, <code>real</code>, <code>static</code> etc. However these things are not fixed, and you should
-check the language file to see what key you want. Having a familiarity with a language file is definately a plus for
+check the language file to see what key you want. Having a familiarity with a language file is definetely a plus for
 using it.</p>
 
 <p>To change the styles for a keyword set, call the <code class="highlighted php">set_keyword_group_style<span class="br0">&#40;</span><span class="br0">&#41;</span></code> method:</p>
@@ -1395,7 +1396,7 @@ and Brackets among other things can all also be highlighted. Here are the relate
 
 <p><code class="highlighted php"><span class="re0">$styles</span></code> is a string containing valid stylesheet declarations, while <code class="highlighted php"><span class="re0">$preserve_defaults</span></code> should be set
 to <code class="highlighted php"><span class="kw4">true</span></code> if you want your styles to be merged with the previous styles. In the case of <code class="highlighted php">set_methods_style<span class="br0">&#40;</span><span class="br0">&#41;</span></code>,
-you should select a group to set the styles of, check the language files for the number used for each &#8220;object splitter&#8221;.</p>
+you should select a group to set the styles of; check the language files for the number used for each &#8220;object splitter&#8221;.</p>
 
 <p>Like this was possible for <code class="highlighted php">set_method_style</code> a new parameter has been introduced for
 <code class="highlighted php">set_symbols_style</code> too which allows you to select the group of symbols for which you&#8217;d like to change your
@@ -1419,7 +1420,7 @@ case, and also control whether keywords are checked in a case sensitive manner.<
 <h4 id="auto-caps-nocaps">3.5.1 Auto-Caps/NoCaps</h4><div class="nav"><a href="#case-caps">Previous</a> | <a href="#case-caps">Top</a> | <a href="#setting-case-sensitivity">Next</a></div>
 
 <p>Auto-Caps/NoCaps is a nifty little feature that capitalises or lowercases automatically certain lexics when they are
-styled. I dabble in QuickBASIC, a dialect of BASIC which is well known for it&#8217;s capatalisation, and SQL is another
+styled. I dabble in QuickBASIC, a dialect of BASIC which is well known for its capitalisation, and SQL is another
 language well known for using caps for readability.</p>
 
 <p>To change what case lexics are rendered in, you call the <code class="highlighted php">set_case_keywords<span class="br0">&#40;</span><span class="br0">&#41;</span></code> method:</p>
@@ -1472,7 +1473,7 @@ for that language), and <code class="highlighted php"><span class="re0">$sensiti
 
 <h3 id="changing-config">3.6 Changing the Source, Language, Config Options</h3><div class="nav"><a href="#setting-case-sensitivity">Previous</a> | <a href="#advanced-features">Top</a> | <a href="#changing-the-source">Next</a></div>
 
-<p>What happens if you want to change the source to be highlighted on the fly, or the language. Or if you want to specify
+<p>What happens if you want to change the source to be highlighted on the fly, or the language? Or if you want to specify
 any of those basic fields after you&#8217;ve created a <abbr title="Generic Syntax Highlighter">GeSHi</abbr> object? Well, that&#8217;s where these methods come in.</p>
 
 <h4 id="changing-the-source">3.6.1 Changing the Source Code</h4><div class="nav"><a href="#changing-config">Previous</a> | <a href="#changing-config">Top</a> | <a href="#changing-the-language">Next</a></div>
@@ -1567,7 +1568,7 @@ like <code class="highlighted php">load_from_file</code> it accepts an optional 
 
 <div class="caution-header">Caution:</div>
 
-<p><abbr title="Generic Syntax Highlighter">GeSHi</abbr> <code class="highlighted php"><span class="kw1">include</span><span class="br0">&#40;</span><span class="br0">&#41;</span></code>s the language file, so be careful to make sure that users can&#8217;t pass some wierd
+<p><abbr title="Generic Syntax Highlighter">GeSHi</abbr> <code class="highlighted php"><span class="kw1">include</span><span class="br0">&#40;</span><span class="br0">&#41;</span></code>s the language file, so be careful to make sure that users can&#8217;t pass some weird
   language name to include any old script! <abbr title="Generic Syntax Highlighter">GeSHi</abbr> tries to strip non-valid characters out of a language name, but
   you should always do this your self anyway. In particular, language files are always lower-case, with either
   alphanumeric characters, dashes or underscores in their name.</p>
@@ -1584,7 +1585,7 @@ language file location? You call the <code class="highlighted php">set_language_
 <p><code class="highlighted php"><span class="re0">$geshi</span><span class="sy0">-&gt;</span><span class="me1">set_language_path</span><span class="br0">&#40;</span><span class="re0">$newpath</span><span class="br0">&#41;</span><span class="sy0">;</span></code></p>
 
 <p>It doesn&#8217;t matter whether the path has a trailing slash after it or not - only that it points to a valid folder.
-If it doesn&#8217;t, that&#8217;s your tough luck ;)</p>
+If it doesn&#8217;t, that&#8217;s your tough luck. ;)</p>
 
 <h4 id="changing-the-charset">3.6.4 Changing the Character Set</h4><div class="nav"><a href="#changing-the-path">Previous</a> | <a href="#changing-config">Top</a> | <a href="#error-handling">Next</a></div>
 
@@ -1596,7 +1597,7 @@ If it doesn&#8217;t, that&#8217;s your tough luck ;)</p>
   will need to set this option when processing sources where multi-byte characters can occur.
   As of <abbr title="Generic Syntax Highlighter">GeSHi</abbr> 1.0.7.18 internally a rewrite of <code class="highlighted php"><span class="kw3">htmlspecialchars</span></code> is used
   due to a security flaw in that function that is unpatched in even the most recent PHP4 versions and in PHP5 &lt; 5.2.
-  Although this does no longer explicitely require the charset it is required again
+  Although this does no longer explicitly require the charset it is required again
   as of <abbr title="Generic Syntax Highlighter">GeSHi</abbr> 1.0.8 to properly handle multi-byte characters (e.g. after an escape char).</p>
 
 </div>
@@ -1648,12 +1649,12 @@ series of <code class="highlighted php">set_<span class="sy0">*</span>_highlight
 <dd>Sets whether a particular <code class="highlighted php"><span class="re0">$group</span></code> of keywords is to be highlighted or not. Consult the necessary
 language file(s) to see what <code class="highlighted php"><span class="re0">$group</span></code> should be for each group (typically a positive integer).
 <code class="highlighted php"><span class="re0">$flag</span></code> is <code class="highlighted php"><span class="kw4">false</span></code> if you want to disable highlighting of this group, and <code class="highlighted php"><span class="kw4">true</span></code> if you want
-to re-enable higlighting of this group. If you disable a keyword group then even if the keyword group has a
+to re-enable highlighting of this group. If you disable a keyword group then even if the keyword group has a
 related URL one will not be generated for that keyword.</dd>
 
 <dt><code class="highlighted php">set_comments_highlighting<span class="br0">&#40;</span><span class="re0">$group</span><span class="sy0">,</span> <span class="re0">$flag</span><span class="br0">&#41;</span><span class="sy0">:</span></code></dt>
 <dd>Sets whether a particular <code class="highlighted php"><span class="re0">$group</span></code> of comments is to be highlighted or not. Consult the necessary
-language file(s) to see what <code class="highlighted php"><span class="re0">$group</span></code> should be for each group (typically a positive integer, or th
+language file(s) to see what <code class="highlighted php"><span class="re0">$group</span></code> should be for each group (typically a positive integer, or the
 string <code class="highlighted php"><span class="st_h">'MULTI'</span></code> for multiline comments. <code class="highlighted php"><span class="re0">$flag</span></code> is <code class="highlighted php"><span class="kw4">false</span></code> if you want to disable
 highlighting of this group, and <code class="highlighted php"><span class="kw4">true</span></code> if you want to re-enable highlighting of this group.</dd>
 
@@ -1675,13 +1676,13 @@ and <code class="highlighted php"><span class="kw4">true</span></code> if you wa
 </ul>
 
 <p>Work on their respective lexics (e.g. <code class="highlighted php">set_methods_highlighting<span class="br0">&#40;</span><span class="br0">&#41;</span></code> will disable/enable highlighting of methods).
-For each method, if <code class="highlighted php"><span class="re0">$flag</span></code> is <code class="highlighted php"><span class="kw4">false</span></code> then the related lexics will not be highlighted at all (this
-means no <abbr title="Hypertext Markup Language">HTML</abbr> will surround the lexic like usual, saving on time and bandwidth.</p>
+For each method, if <code class="highlighted php"><span class="re0">$flag</span></code> is <code class="highlighted php"><span class="kw4">false</span></code> then the related lexics will not be highlighted at all. (This
+means no <abbr title="Hypertext Markup Language">HTML</abbr> will surround the lexic like usual, saving on time and bandwidth.)</p>
 
 <p>In case all highlighting should be disabled or reenabled <abbr title="Generic Syntax Highlighter">GeSHi</abbr> provides two methods called <code class="highlighted php">disable_highlighting<span class="br0">&#40;</span><span class="br0">&#41;</span></code>
-and <code class="highlighted php">enable_highlighting<span class="br0">&#40;</span><span class="re0">$flag</span><span class="br0">&#41;</span></code>. The optional paramter <code class="highlighted php"><span class="re0">$flag</span></code> has been added in 1.0.7.21 and specifies
+and <code class="highlighted php">enable_highlighting<span class="br0">&#40;</span><span class="re0">$flag</span><span class="br0">&#41;</span></code>. The optional parameter <code class="highlighted php"><span class="re0">$flag</span></code> has been added in 1.0.7.21 and specifies
 the desired state, i.e. <code class="highlighted php"><span class="kw4">true</span></code> (default) to turn all highlighting on, or <code class="highlighted php"><span class="kw4">false</span></code> to turn all
-highlighting off. Since 1.0.7.21 the method <code class="highlighted php">disnable_highlighting<span class="br0">&#40;</span><span class="br0">&#41;</span></code> has become deprecated.</p>
+highlighting off. Since 1.0.7.21 the method <code class="highlighted php">disable_highlighting<span class="br0">&#40;</span><span class="br0">&#41;</span></code> has become deprecated.</p>
 
 <h3 id="setting-tab-width">3.9 Setting the Tab Width</h3><div class="nav"><a href="#disabling-lexics">Previous</a> | <a href="#advanced-features">Top</a> | <a href="#using-strict-mode">Next</a></div>
 
@@ -1766,7 +1767,7 @@ the word to add.</p>
 <p>This implies knowledge of the language file to know the correct index - most of the time the keywords you&#8217;ll
 want to remove will be in group 3, but this is not guaranteed and you should check the language file first.</p>
 
-<p>This function is silent - if the keyword is not in the group you specified, nothing awful will happen ;)</p>
+<p>This function is silent - if the keyword is not in the group you specified, nothing awful will happen. ;)</p>
 
 <h4 id="adding-a-keyword-group">3.11.3 Adding a Keyword Group</h4><div class="nav"><a href="#removing-a-keyword">Previous</a> | <a href="#adding-removing-keywords">Top</a> | <a href="#removing-a-keyword-group">Next</a></div>
 
@@ -1804,7 +1805,7 @@ can be in any case and which contains the keywords &#8220;myfunc_1&#8221;, &#822
 <h4 id="removing-a-keyword-group">3.11.4 Removing a Keyword Group</h4><div class="nav"><a href="#adding-a-keyword-group">Previous</a> | <a href="#adding-removing-keywords">Top</a> | <a href="#headers-and-footers">Next</a></div>
 
 <p>Perhaps you <em>really</em> need speed? Why not just remove an entire keyword group? <abbr title="Generic Syntax Highlighter">GeSHi</abbr> won&#8217;t have to loop through
-each keyword checking for its existance, saving much time. You remove a keyword group by using the
+each keyword checking for its existence, saving much time. You remove a keyword group by using the
 <code class="highlighted php">remove_keyword_group</code> method:</p>
 
 <p><code class="highlighted php"><span class="re0">$geshi</span><span class="sy0">-&gt;</span><span class="me1">remove_keyword_group</span><span class="br0">&#40;</span><span class="re0">$key</span><span class="br0">&#41;</span><span class="sy0">;</span></code></p>
@@ -3206,9 +3207,9 @@ still, there&#8217;s a lot of indices to that array&#8230; but this section is h
 files should obey the following rules:</p>
 
 <ul>
-<li><strong>Indentation is <em>4 spaces</em>, not tabs:</strong> Use spaces! as editors continiously screw up tabs there should be
+<li><strong>Indentation is <em>4 spaces</em>, not tabs:</strong> Use spaces! As editors continuously screw up tabs there should be
 no tabs in your documents since it would look differently on every computer otherwise.</li>
-<li><strong>Strings are in single quotes:</strong> Every string in a language file should be in single quotes (&#8216;), unless you are
+<li><strong>Strings are in single quotes:</strong> Every string in a language file should be in single quotes ('), unless you are
 specifying a single quote as a quotemark or escape character, in which case they can be in double quotes for
 readability; or if you are specifying a REGEXP (see below). This ensures that the language file can be loaded
 as fast as possible by <abbr title="PHP: HTML Preprocessor">PHP</abbr> as unnecessary parsing can be avoided.</li>
@@ -3217,10 +3218,10 @@ lines. In any case, lines should not be wider than a full-screen window (about 1
 Don&#8217;t break the keywords arrays after every keyword.</li>
 <li><strong>Ending brackets for multi-lined arrays on a new line:</strong> Also with a comma after them, unless the array is
 the last one in a parent array. See the <abbr title="PHP: HTML Preprocessor">PHP</abbr> language file for examples of where to use commas.</li>
-<li><strong>Use <abbr title="Generic Syntax Highlighter">GeSHi</abbr>&#8217;s constants:</strong> For capatalisation, regular expressions etc. use the <abbr title="Generic Syntax Highlighter">GeSHi</abbr> constants, <em>not</em>
+<li><strong>Use <abbr title="Generic Syntax Highlighter">GeSHi</abbr>&#8217;s constants:</strong> For capitalisation, regular expressions etc. use the <abbr title="Generic Syntax Highlighter">GeSHi</abbr> constants, <em>not</em>
 their actual values.</li>
 <li><strong>Verbatim header format:</strong> Copy the file header verbatim from other language files and modify the values
-afterwards. Don&#8217;t try to invent own header formats, as your languages else will fail validation!</li>
+afterwards. Don&#8217;t try to invent your own header formats, as your languages else will fail validation!</li>
 </ul>
 
 <p>There are more notes on each convention where it may appear in the language file sections below.</p>
@@ -3286,12 +3287,12 @@ afterwards. Don&#8217;t try to invent own header formats, as your languages else
 <ul>
 <li><code>&lt;name-of-language-file.php&gt;</code> - This should become the name of your language file. Language file names are in
 lower case and contain only alphanumeric characters, dashes and underscores. Language files end with .php (which
-you should put with the name of your language file, eg language.php)</li>
+you should put with the name of your language file, eg language.php).</li>
 <li><code>&lt;name&gt;</code> - Your name, or alias.</li>
 <li><code>&lt;e-mail address&gt;</code> - Your e-mail address. If you want your language file included with <abbr title="Generic Syntax Highlighter">GeSHi</abbr> you <em>must</em>
 include an e-mail address that refers to an inbox controlled by you.</li>
 <li><code>&lt;website&gt;</code> - A URL of a website of yours (perhaps to a page that deals with your contribution to <abbr title="Generic Syntax Highlighter">GeSHi</abbr>, or
-your home page/blog)</li>
+your home page/blog).</li>
 <li><code>&lt;date-started&gt;</code> - The date you started working on the language file. If you can&#8217;t remember, guestimate.</li>
 <li><code>&lt;name-of-language&gt;</code> - The name of the language you made this language file for (probably similar to
 the language file name).</li>
@@ -3307,7 +3308,7 @@ So if you have version 1.0.8 of <abbr title="Generic Syntax Highlighter">GeSHi</
 <p>Everything should remain the same.</p>
 
 <p><strong>Also:</strong> I&#8217;m not sure about the copyright on a new language file. I&#8217;m not a lawyer, could someone contact me about
-whether the copyright for a new language file should be exclusivly the authors, or joint with me (if included in a
+whether the copyright for a new language file should be exclusively the authors, or joint with me (if included in a
 <abbr title="Generic Syntax Highlighter">GeSHi</abbr> release)?</p>
 
 <h4 id="language-file-start-indices">4.3.2 The First Indices</h4><div class="nav"><a href="#language-file-header">Previous</a> | <a href="#language-file-sections">Top</a> | <a href="#language-file-keywords">Next</a></div>
@@ -3331,7 +3332,7 @@ whether the copyright for a new language file should be exclusivly the authors, 
 from 1. A single line comment is a comment that starts at the marker and goes until the end of the line. These
 comments may be any length > 0, and since they can be styled individually, can be used for other things than comments
 (for example the Java language file defines &#8220;import&#8221; as a single line comment). If you are making a language that
-uses a &#8217; (apostrophe) as a comment (or in the comment marker somewhere), use double quotes. e.g.: &#8220;&#8217;&#8221;</li>
+uses a ' (apostrophe) as a comment (or in the comment marker somewhere), use double quotes. e.g.: &#8220;'&#8221;.</li>
 <li><strong>&#8216;COMMENT_MULTI&#8217;:</strong> Used to specify multiline comments, an array in the form &#8216;OPEN&#8217; => &#8216;CLOSE&#8217;. Unfortunately,
 all of these comments you add here will be styled the same way (an area of improvement for <abbr title="Generic Syntax Highlighter">GeSHi</abbr> 1.2.X).
 These comment markers may be any length > 0.</li>
@@ -3341,7 +3342,7 @@ For example, in an SQL or BASIC dialect you may want all keywords to be upper ca
 <li><code>GESHI_CAPS_LOWER</code>: Convert the case of all keywords to lower case.</li>
 <li><code>GESHI_CAPS_NO_CHANGE</code>: Don&#8217;t change the case of any keyword.</li>
 <li><strong>&#8216;QUOTEMARKS&#8217;:</strong> Specifies the characters that mark the beginning and end of a string. This is another example
-where if your language includes the &#8217; string delimiter you should use double quotes around it.</li>
+where if your language includes the ' string delimiter you should use double quotes around it.</li>
 <li><strong>&#8216;ESCAPE_CHAR&#8217;:</strong> Specifies the escape character used in all strings. If your language does not have an escape
 character then make this the empty string (<code>''</code>). This is not an array! If found, any character after an
 escape character and the escape character itself will be highlighted differently, and the character after the
@@ -3414,8 +3415,8 @@ building some of its caches, so the order doesn&#8217;t matter, but makes things
 <li><strong>Keywords are case sensitive (sometimes):</strong> If your language is case-sensitive, the correct casing of the
 keywords is defined as the case of the keywords in these keyword arrays. If you check the java language file you
 will see that everything is in exact casing. So if any of these keyword arrays are case sensitive, put the
-keywords in as their correct case! (note that which groups are case sensitive and which are not is configurable,
-see later on). If a keyword group is case insensitive, put the lowercase version of the keyword here
+keywords in as their correct case! (Note that which groups are case sensitive and which are not is configurable,
+see later on.) If a keyword group is case insensitive, put the lowercase version of the keyword here
 <strong>OR</strong> in case documentation links require a special casing (other than all lowercase or all uppercase)
 the casing required for them use their casing.</li>
 <li><strong>Keywords must be in <code class="highlighted php"><span class="kw3">htmlentities</span><span class="br0">&#40;</span><span class="br0">&#41;</span></code> form:</strong> All keywords should be written as if they had been
@@ -3447,7 +3448,7 @@ each containing only a subset of the symbols to highlight. Every array will need
 you can assign the appropriate styles later.</dd>
 </dl>
 
-<p>Here&#8217;s an example for flat symbol usage</p>
+<p>Here&#8217;s an example for flat symbol usage:</p>
 
 <table class="php geshicode"><thead><tr><td colspan="2"  class="head">PHP code</td></tr></thead><tbody><tr class="li1"><td class="ln"><pre class="de1">1
 <span class="xtra li2"><span class="de2">2</span></span>3
@@ -3478,9 +3479,9 @@ you can assign the appropriate styles later.</dd>
 <p>The following case sensitivity group alludes to the keywords section: here you can set which keyword groups are case sensitive.</p>
 
 <p>In the <strong>&#8216;CASE_SENSITIVE&#8217;</strong> group there&#8217;s a special key <code>GESHI_COMMENTS</code> which is used to set whether comments are
-case sensitive or not (for example, BASIC has the REM statement which while not being case sensitive is still alphanumeric, and
+case sensitive or not. (For example, BASIC has the REM statement which while not being case sensitive is still alphanumeric, and
 as in the example given before about the Java language file using &#8220;import&#8221; as a single line comment, this can be
-useful sometimes. <strong>true</strong> if comments are case sensitive, <strong>false</strong> otherwise. All of the other indices
+useful sometimes.) <strong>true</strong> if comments are case sensitive, <strong>false</strong> otherwise. All of the other indices
 correspond to indices in the <code>'KEYWORDS'</code> section (see above).</p>
 
 <h4 id="language-file-styles">4.3.5 Styles for your Language File</h4><div class="nav"><a href="#language-file-symbols-case">Previous</a> | <a href="#language-file-sections">Top</a> | <a href="#language-file-urls">Next</a></div>
@@ -3531,11 +3532,11 @@ language file.</p>
 <span class="xtra li2"><span class="de2">&nbsp; &nbsp; &nbsp; &nbsp; <span class="nu0">2</span> <span class="sy0">=&gt;</span> <span class="st_h">''</span><span class="sy0">,</span></span></span>&nbsp; &nbsp; &nbsp; &nbsp; <span class="nu0">3</span> <span class="sy0">=&gt;</span> <span class="st_h">''</span>
 <span class="xtra li2"><span class="de2">&nbsp; &nbsp; &nbsp; &nbsp; <span class="br0">&#41;</span></span></span>&nbsp; &nbsp; <span class="br0">&#41;</span><span class="sy0">,</span></pre></td></tr></tbody></table>
 
-<p>Note that all style rules should end with a semi-colon! This is important: <abbr title="Generic Syntax Highlighter">GeSHi</abbr> may add extra rules to the rules you
-specify (and will do so if a user tries to change your styles on the fly), so the last semi-colon in any stylesheet
+<p>Note that all style rules should end with a semicolon! This is important: <abbr title="Generic Syntax Highlighter">GeSHi</abbr> may add extra rules to the rules you
+specify (and will do so if a user tries to change your styles on the fly), so the last semicolon in any stylesheet
 rule is important!</p>
 
-<p>All strings here should contain valid stylesheet declarations (it&#8217;s also fine to have the empty string).</p>
+<p>All strings here should contain valid stylesheet declarations. (It&#8217;s also fine to have the empty string).</p>
 
 <ul>
 <li><strong>&#8216;KEYWORDS&#8217;:</strong> This is an array, from keyword index to style. The index you use is the index you used in
@@ -3558,7 +3559,7 @@ name of a function to be called, that will be given the text matched by the rege
 Note that my testing found that <code>create_function</code> would not work with this due to a <abbr title="PHP: HTML Preprocessor">PHP</abbr> bug
 (not to mention that <code>create_function</code> is deprecated as of <abbr title="PHP: HTML Preprocessor">PHP</abbr> 7.2.0), so you have to
 put the function definition at the top of the language file. Be sure to prefix the function name
-with <code>geshi_[languagename]_</code> as to not conflict with other functions!</li>
+with <code>geshi_[languagename]_</code> so as to not conflict with other functions!</li>
 <li><strong>&#8216;SCRIPT&#8217;:</strong> For languages that use script delimiters, this is where you can style each block of script. For
 example, <abbr title="Hypertext Markup Language">HTML</abbr> and <abbr title="Extensible Markup Language">XML</abbr> have blocks that begin with &lt; and end with > (i.e. tags) and blocks that begin with &amp; and
 end with&#160;; (i.e. character entities), and you can set a style to apply to each whole block. You specify the
@@ -3567,7 +3568,7 @@ delimiters for the blocks below. Note that many languages will not need this fea
 
 <h4 id="language-file-urls">4.3.6 URLs for Functions</h4><div class="nav"><a href="#language-file-styles">Previous</a> | <a href="#language-file-sections">Top</a> | <a href="#language-file-numbers-support">Next</a></div>
 
-<p>This section lets you specify a url to visit for each keyword group. Useful for pointing functions at their online
+<p>This section lets you specify a URL to visit for each keyword group. Useful for pointing functions at their online
 manual entries.</p>
 
 <p>Here is an example:</p>
@@ -3584,12 +3585,12 @@ manual entries.</p>
 marks where the name of the function is substituted in. So for the example above, if the keyword being highlighted is
 &#8220;echo&#8221;, then the keyword will be a URL pointing to <code>http://www.php.net/echo</code>. Because some languages (Java!) don&#8217;t
 keep a uniform URL for functions/classes, you may have trouble in creating a URL for that language (though look in the
-java language file for a novel solution to it&#8217;s problem)</p>
+java language file for a novel solution to it&#8217;s problem).</p>
 
 <h4 id="language-file-numbers-support">4.3.7 Number Highlighting Support</h4><div class="nav"><a href="#language-file-urls">Previous</a> | <a href="#language-file-sections">Top</a> | <a href="#language-file-oo-support">Next</a></div>
 
 <p>If your language supports different formats of numbers (e.g. integers and float representations) and you want
-<abbr title="Generic Syntax Highlighter">GeSHi</abbr> to handle them differently you can select from a set of predefined formats.</p>
+<abbr title="Generic Syntax Highlighter">GeSHi</abbr> to handle them differently, you can select from a set of predefined formats.</p>
 
 <table class="php geshicode"><thead><tr><td colspan="2"  class="head">PHP code</td></tr></thead><tbody><tr class="li1"><td class="ln"><pre class="de1">1
 <span class="xtra li2"><span class="de2">2</span></span>3
@@ -3644,7 +3645,7 @@ tell it to do so and what the &#8220;splitter&#8221; is between object/method et
 <span class="xtra li2"><span class="de2">2</span></span></pre></td><td class="de1"><pre class="de1"><span class="st_h">'OOLANG'</span> <span class="sy0">=&gt;</span> <span class="kw4">true</span><span class="sy0">,</span>
 <span class="xtra li2"><span class="de2"><span class="st_h">'OBJECT_SPLITTER'</span> <span class="sy0">=&gt;</span> <span class="st_h">'-&amp;gt;'</span><span class="sy0">,</span></span></span></pre></td></tr></tbody></table>
 
-<p>If your language has object orientation, the value of <code>'OOLANG'</code> is true, otherwise it is false. If it is object
+<p>If your language has object orientation, the value of <code>'OOLANG'</code> is true; otherwise it is false. If it is object
 orientated, in the <code>'OBJECT_SPLITTER'</code> value you put the <code>htmlentities()</code> version of the &#8220;splitter&#8221; between
 objects and methods/fields. If it is not, then make this the empty string.</p>
 
@@ -3714,7 +3715,7 @@ string of <code>\\1</code> <small>(whew!)</small>.</li>
 </ul>
 
 <p>If you didn&#8217;t understand a word of that, make sure that there are brackets around the string in <code>GESHI_SEARCH</code>
-and use <code>\\1</code> for <code>GESHI_REPLACE</code> ;)</p>
+and use <code>\\1</code> for <code>GESHI_REPLACE</code>. ;)</p>
 
 <ul>
 <li><strong>GESHI_MODIFIERS:</strong> Specify modifiers for your regular expression. If your regular expression includes the
@@ -3837,7 +3838,7 @@ style the overall block using the method described above, and the <abbr title="E
 <p>Since <abbr title="Generic Syntax Highlighter">GeSHi</abbr> 1.0.8 instead of specifying an array with starter and ender you may also provide a regular expression
 that matches <em>the full block</em> you wish to highlight. If the regular expression match starts at the same position
 as a previous array declaration the Regexp match is taken. This is to allow for a fall-back when a preg_match
-doesn&#8217;t quite work as expected so you still get reasonably well results.</p>
+doesn&#8217;t quite work as expected so you still get reasonably good results.</p>
 
 <p>If you didn&#8217;t get this, you might want to look into the <abbr title="PHP: HTML Preprocessor">PHP</abbr> or <abbr title="Hypertext Markup Language">HTML</abbr> language files as this feature is used there
 to fix some issues that have been there for about 3 years.</p>
@@ -3846,7 +3847,7 @@ to fix some issues that have been there for about 3 years.</p>
 
 <div class="caution-header">Caution:</div>
 
-<p>For <abbr title="PHP: HTML Preprocessor">PHP</abbr> versions &lt;4.3.3 Strict Block Regexps are completely ignored due to problems in those version
+<p>For <abbr title="PHP: HTML Preprocessor">PHP</abbr> versions &lt;4.3.3 Strict Block Regexps are completely ignored due to problems in those versions
   that would cause loads of warning messages otherwise.</p>
 
 </div>
@@ -3875,7 +3876,7 @@ No validation of settings is performed for these settings. Also note that unknow
 Usually <abbr title="Generic Syntax Highlighter">GeSHi</abbr> checks for a fixed set of characters like brackets and common symbols that denote the word boundary for a keyword.
 If this set conflicts with your language (e.g. - is allowed inside a keyword) or you want to limit the usage of a keyword to certain areas (e.g. for <abbr title="Hypertext Markup Language">HTML</abbr> tag names only match after &lt;) you can change those conditions here.</p>
 
-<p>Keyword boundary rules can either be set globally (directly within the PARSER_CONTROL&#8217;s KEYWORDS section or on a per-group basis.
+<p>Keyword boundary rules can either be set globally (directly within the PARSER_CONTROL&#8217;s KEYWORDS section) or on a per-group basis.
 E.g. the following sample from the <abbr title="Hypertext Markup Language">HTML</abbr> language file sets different settings for keyword matching only for Keyword Group 2 and leaves the other groups alone.</p>
 
 <table class="php geshicode"><thead><tr><td colspan="2"  class="head">PHP code</td></tr></thead><tbody><tr class="li1"><td class="ln"><pre class="de1">1
@@ -3929,10 +3930,10 @@ This might come in handy if the language file you are working on doesn&#8217;t s
 
 <p>Inside the <code class="highlighted php"><span class="st_h">'ENABLE_FLAGS'</span></code> section follows an array of <code class="highlighted php"><span class="st_h">'name'</span><span class="sy0">=&gt;</span>value</code> pairs.
 Valid names are the sections below the <code class="highlighted php"><span class="st_h">'STYLES'</span></code> section (well, not exactly, but you can look there for what the features are called inside <abbr title="Generic Syntax Highlighter">GeSHi</abbr>).
-Valid values are the <abbr title="Generic Syntax Highlighter">GeSHi</abbr> constants <code class="highlighted php">GESHI_NEVER</code> (don&#8217;t process this feature), <code class="highlighted php">GESHI_ALWAYS</code> (always process this feature, ignore the user) and <code class="highlighted php">GESHI_MAYBE</code> (listen to the user if he want&#8217;s this highlighted).
-The value <code class="highlighted php">GESHI_MAYBE</code> is the default one and thus needs not to be set explicitely.</p>
+Valid values are the <abbr title="Generic Syntax Highlighter">GeSHi</abbr> constants <code class="highlighted php">GESHI_NEVER</code> (don&#8217;t process this feature), <code class="highlighted php">GESHI_ALWAYS</code> (always process this feature, ignore the user) and <code class="highlighted php">GESHI_MAYBE</code> (listen to the user if he wants this highlighted).
+The value <code class="highlighted php">GESHI_MAYBE</code> is the default one and thus needs not to be set explicitly.</p>
 
-<p>Another setting available through the <strong>PARSER_CONTROL</strong> settings is the possibility to limit the allowed characters before an single line comment.</p>
+<p>Another setting available through the <strong>PARSER_CONTROL</strong> settings is the possibility to limit the allowed characters before a single line comment.</p>
 
 <table class="php geshicode"><thead><tr><td colspan="2"  class="head">PHP code</td></tr></thead><tbody><tr class="li1"><td class="ln"><pre class="de1">1
 <span class="xtra li2"><span class="de2">2</span></span>3
@@ -3951,7 +3952,7 @@ The value <code class="highlighted php">GESHI_MAYBE</code> is the default one an
 
 </div>
 
-<p>Another <strong>PARSER_CONTROL</strong> setting for the environment around certain syntactic constructs refers to the handling of object-oriented languages.</p>
+<p>Another <strong>PARSER_CONTROL</strong> setting for the environment around certain syntactic constructs refers to the handling of object-orientated languages.</p>
 
 <table class="php geshicode"><thead><tr><td colspan="2"  class="head">PHP code</td></tr></thead><tbody><tr class="li1"><td class="ln"><pre class="de1">1
 <span class="xtra li2"><span class="de2">2</span></span>3
@@ -4019,7 +4020,7 @@ be confusing for you. Or perhaps I was just plain wrong about one point! If so, 
 thread will be of the bug-fix/add language files type. In particular, version 1.0.2 was a &#8220;concept&#8221; release - testing
 how far I could take the highlighting idea (as well as ideas from others).</p>
 
-<p>I&#8217;m planning a code rewrite for 1.2.X, which will be based on a new engine - a &#8220;psuedo-tokenizer&#8221; engine. Hopefully
+<p>I&#8217;m planning a code rewrite for 1.2.X, which will be based on a new engine - a &#8220;pseudo-tokenizer&#8221; engine. Hopefully
 it will massively reduce the server load and time taken (by almost eliminating regexps), while providing
 superior highlighting. But fear not! The interface and method names should all remain the same ^_^ (though I can&#8217;t
 say the same for language files!)</p>
@@ -4051,7 +4052,7 @@ you like, though flick me an e-mail if you do.</p>
 <ol>
 
 <li id="fn:xhtml-strict">
-<p>The PRE header (see <a href="#the-code-container">The Code Container</a>) is not valid <abbr title="Hypertext Markup Language">HTML</abbr>, you might want
+<p>The PRE header (see <a href="#the-code-container">The Code Container</a>) is not valid <abbr title="Hypertext Markup Language">HTML</abbr>; you might want
 to use one of the other header types instead.&#160;<a href="#fnref:xhtml-strict" rev="footnote">&#8617;</a></p>
 </li>
 


### PR DESCRIPTION
Just some minor typo and formatting fixes to the geshi-doc file.

* Typo and spelling fixes
* For places where apostrophes should be literal apostrophes because they're referring to that exact character in a programming language, undo their styling as curly quotes
* Add periods to end of sentences which are closed only with smileys
* Fix a broken footnote link for MediaWiki
* Update the download link to where it's currently redirecting to
* Replace comma splices with semicolons