### PR TITLE
geshi-doc: change letter spacing to normal for readability

### DIFF
--- a/docs/geshi-doc.html
+++ b/docs/geshi-doc.html
@@ -22,7 +22,7 @@
             p, ul, ol, div, blockquote, dt, dd {
                 font-size: 80%;
                 line-height: 140%;
-                letter-spacing: 1px;
+                letter-spacing: normal;
                 color: #002;
             }
             dt {


### PR DESCRIPTION
The full 1px letter spacing in the doco page seems a bit excessive, and makes the doc harder to read IMHO. What do you think about reverting it to normal spacing?

Before:

<img width="1259" alt="screen shot 2018-12-16 at 2 08 16 am" src="https://user-images.githubusercontent.com/2618447/50051011-84f30b00-00d7-11e9-9676-06f93d3016b4.png">


After:

<img width="1259" alt="screen shot 2018-12-16 at 2 08 27 am" src="https://user-images.githubusercontent.com/2618447/50051012-891f2880-00d7-11e9-87b0-37ba5d1d8a3f.png">
