### PR TITLE
Correct license in build.xml to GPL (was AGPL)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,7 @@ Version 1.0.9.0
      <channel>pear.geshi.org</channel>
 
      <lead user="benbe" name="Benny Baumann" email="benbe@geshi.org" />
-     <license>AGPL</license>
+     <license>GPL</license>
 
      <version   release="${version}"   api="${version}" />
      <stability release="${stability}" api="${stability}" />


### PR DESCRIPTION
The LICENSE file and other documentation says that GeSHi is licensed under GPL 2.0. But the build.xml file declares it to be AGPL. That's the Aferro GPL license, which has significant additional restrictions about use in service-provider contexts, and isn't the same as GPL-2.0. Should it be "GPL" instead?