### PR TITLE
matlab.php: update help link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Version 1.0.9.1
   -  Code style update by avoiding create_function (cweiske)
   -  Backported CLI tool from GeSHi 1.1 branch (cweiske)
   -  Improvements to language files
+     * Matlab: Fix help link (apjanke)
      * MySQL: Some missing keywords (Abu3safeer)
      * MySQL: Updated documentation links (splitbrain)
      * SQL: Some missing keywords (peterdd)

--- a/src/geshi/matlab.php
+++ b/src/geshi/matlab.php
@@ -206,7 +206,7 @@ $language_data = array (
         ),
     'URLS' => array(
         1 => '',
-        2 => 'http://www.mathworks.com/access/helpdesk/help/techdoc/ref/{FNAMEL}.html'
+        2 => 'https://www.mathworks.com/help/matlab/ref/{FNAMEL}.html'
         ),
     'OOLANG' => true,
     'OBJECT_SPLITTERS' => array(


### PR DESCRIPTION
The MathWorks help URLs have changed. This updates the `matlab.php` file to use the new link, saving users a couple redirects and possible broken links in the future.