### PR TITLE
Fix get_language_name for unknown languages

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -611,7 +611,7 @@ class GeSHi {
      */
     public function get_language_name() {
         if (GESHI_ERROR_NO_SUCH_LANG == $this->error) {
-            return $this->language_data['LANG_NAME'] . ' (Unknown Language)';
+            return $this->language . ' (Unknown Language)';
         }
         return $this->language_data['LANG_NAME'];
     }


### PR DESCRIPTION
If the language is not known, then language_data will not be initialized properly. We should therefore use the user's language input instead.