### PR TITLE
Add PHP 7.2/7.3 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: php
-sudo: false
+
 php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
   - nightly
-  - hhvm
 matrix:
   allow_failures:
-    - php: "hhvm"
     - php: "nightly"
 before_script:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "classmap": ["src/geshi/", "src/geshi.php"]
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.2"
     }
 }

--- a/tests/LangCheckTest.php
+++ b/tests/LangCheckTest.php
@@ -1,7 +1,10 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 require_once __DIR__ . '/LangCheck.php';
 
-class LangCheckTest extends PHPUnit_Framework_TestCase
+class LangCheckTest extends TestCase
 {
     /**
      * Read all available language files


### PR DESCRIPTION
* Add PHP 7.2/7.3 to Travis
* Remove HHVM because it's no longer supported by Composer and Travis
* Allow new versions of PHPUnit