### PR TITLE
fix: SF Bug 190: highlight_lines_extra eats end-of-line

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,8 @@
          backupStaticAttributes="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
+         convertWarningsToExceptions="true"
+         bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/geshi.php
+++ b/src/geshi.php
@@ -4045,7 +4045,7 @@ class GeSHi {
                   $parsed_code .= str_repeat('</span>', $close);
                   $close = 0;
                 }
-                elseif ($i + 1 < $n) {
+                if ($i + 1 < $n) {
                     $parsed_code .= "\n";
                 }
                 unset($code[$i]);

--- a/tests/NewlineTest.php
+++ b/tests/NewlineTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures the number of output lines are the same as the input
+ */
+class NewlineTest extends TestCase
+{
+
+    /**
+     * No fancy settings
+     */
+    public function testDefault()
+    {
+        $input = <<< END
+void main () {
+    printf ("Hello World");
+    exit 0;
+}
+END;
+        $input_lines = count(explode("\n", $input));
+
+        $geshi = new GeSHi($input, 'c');
+        $geshi->highlight_lines_extra(2);
+        $output = $geshi->parse_code();
+        $output_lines = count(explode("\n", $output));
+
+        $this->assertEquals($input_lines, $output_lines, "number of line mismatch between input and output");
+    }
+
+    /**
+     * Highlighting a line
+     *
+     * checks for SF bug 190
+     *
+     * @link https://sourceforge.net/p/geshi/bugs/190/
+     */
+    public function testHighlight()
+    {
+        $input = <<< END
+void main () {
+    printf ("Hello World");
+    exit 0;
+}
+END;
+        $input_lines = count(explode("\n", $input));
+
+        $geshi = new GeSHi($input, 'c');
+        $geshi->highlight_lines_extra(2);
+        $output = $geshi->parse_code();
+        $output_lines = count(explode("\n", $output));
+
+        $this->assertEquals($input_lines, $output_lines, "number of line mismatch between input and output");
+    }
+}


### PR DESCRIPTION
This applies the proposed fix from https://sourceforge.net/p/geshi/bugs/190/

Because of the lack of comprehensive tests, it's unclear if this has any
side effects, but it does fix the reported problem.

A test case for this bug in particular has been added.