### PR TITLE
chg: always set language name

### DIFF
--- a/src/geshi.php
+++ b/src/geshi.php
@@ -669,6 +669,8 @@ class GeSHi {
         }
 
         $this->language = $language;
+        // ensure the language name is set even if the file cannot be loaded in the next step
+        $this->language_data['LANGUAGE_NAME'] = $language;
 
         //Check if we can read the desired file
         if (!is_readable($file_name)) {


### PR DESCRIPTION
As suggested in #123 this always initializes the language name, even if
the language file cannot be found later.